### PR TITLE
ci: Add release-plz GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+# The action runs on every push to the main branch.
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    # Used to push tags, and create releases.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # `fetch-depth: 0` is needed to clone all the git history, which is necessary to
+          # release from the latest commit of the release PR.
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          # Run `release-plz release` command.
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      # Used to create and update pull requests.
+      pull-requests: write
+      # Used to push to the pull request branch.
+      contents: write
+
+    # The concurrency block is explained below (after the code block).
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # `fetch-depth: 0` is needed to clone all the git history, which is necessary to
+          # determine the next version and build the changelog.
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          # Run `release-plz release-pr` command.
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process for the project. The workflow includes two jobs: one for releasing unpublished packages and another for creating a pull request with the new versions and changelog.

### New GitHub Actions Workflow for Releases:

* **Workflow Name and Trigger**:
  - Added a new workflow named `Release` that runs on every push to the `main` branch. (`.github/workflows/release.yml` - [.github/workflows/release.ymlR1-R65](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R65))

* **Release Unpublished Packages**:
  - Added a `release-plz-release` job to handle releasing unpublished packages. This job uses the `release-plz` action to push tags and create releases, with necessary permissions and environment variables configured. (`.github/workflows/release.yml` - [.github/workflows/release.ymlR1-R65](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R65))

* **Prepare Next Release**:
  - Added a `release-plz-pr` job to create a pull request with the new versions and changelog, preparing for the next release. This job also uses the `release-plz` action and includes a concurrency block to avoid conflicts. (`.github/workflows/release.yml` - [.github/workflows/release.ymlR1-R65](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R65))