### PR TITLE
ci: Run on main or master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 # The action runs on every push to the main branch.
 on:
   push:
-    branches:
-      - main
+    branches: ['main', 'master']
 
 jobs:
 


### PR DESCRIPTION
This pull request updates the release workflow configuration to support multiple branch names for triggering the release action.

Workflow configuration update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L6-R6): Modified the `push` event configuration to include both `main` and `master` branches, allowing the release workflow to trigger on pushes to either branch.