### PR TITLE
ci: Grant release-plz-release job permission to read PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     # Used to push tags, and create releases.
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration to adjust permissions for release jobs.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R17): Added `pull-requests: read` permission under `permissions` in the `jobs:` section to allow read access to pull requests during the release process.