### PR TITLE
chore(nix): bump nixpkgs to 25.05 and update devShell toolchain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742268799,
-        "narHash": "sha256-IhnK4LhkBlf14/F8THvUy3xi/TxSQkp9hikfDZRD4Ic=",
+        "lastModified": 1757408970,
+        "narHash": "sha256-aSgK4BLNFFGvDTNKPeB28lVXYqVn8RdyXDNAvgGq+k0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da044451c6a70518db5b730fe277b70f494188f1",
+        "rev": "d179d77c139e0a3f5c416477f7747e9d6b7ec315",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-24.11";
+      url = "github:nixos/nixpkgs/nixos-25.05";
     };
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
@@ -23,9 +23,13 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            rust-bin.nightly.latest.default
-            rust-bin.nightly.latest.rust-analyzer
+            cargo
+            cargo-semver-checks
+            clippy
+            rust-analyzer
+            rustc
             rust-bin.nightly.latest.rustfmt
+            rustPlatform.rustLibSrc
           ];
 
           RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";


### PR DESCRIPTION
## Changes

- Update `nixpkgs` input to `nixos-25.05` in `flake.nix`.
- Refresh `flake.lock`.
- Replace nightly toolchain with stable `rustc`, `cargo`, and `rust-analyzer`.
- Add `clippy` and `cargo-semver-checks` (for release-plz) for linting and API checks.
- Keep `rust-bin.nightly.latest.rustfmt` for formatting.