### PR TITLE
Refactor http requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "http",
  "log",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "network-programming"]
 [dependencies]
 arc-swap = "1.7"
 async-trait = "0.1"
+http = "1"
 log = "0.4"
 once_cell = "1.21"
 reqwest = { version = "0.12", features = ["json", "cookies"] }

--- a/examples/api_validator/guests.rs
+++ b/examples/api_validator/guests.rs
@@ -1,3 +1,4 @@
+use http::Method;
 use serde_json::Value;
 use unifi_client::{UniFiClient, UniFiResult};
 
@@ -30,7 +31,9 @@ impl GuestsValidator {
         let endpoint = format!("/api/s/{}/cmd/stamgr", site);
 
         // Make raw API call
-        let response: Value = client.raw_request("POST", &endpoint, Some(payload)).await?;
+        let response: Value = client
+            .raw_request(Method::POST, &endpoint, Some(payload))
+            .await?;
 
         // Validate response structure and values
         if let Some(auth) = response.as_array().and_then(|arr| arr.first()) {
@@ -110,12 +113,14 @@ impl GuestsValidator {
 
         // Authorize the guest first
         let _: Value = client
-            .raw_request("POST", &endpoint, Some(auth_payload))
+            .raw_request(Method::POST, &endpoint, Some(auth_payload))
             .await?;
 
         // Get the list of guests
         let endpoint = format!("/api/s/{}/stat/guest", site);
-        let response: Value = client.raw_request("GET", &endpoint, None::<()>).await?;
+        let response: Value = client
+            .raw_request(Method::GET, &endpoint, None::<()>)
+            .await?;
 
         // Validate response is an array
         if let Some(guests) = response.as_array() {
@@ -188,7 +193,7 @@ impl GuestsValidator {
 
         // Authorize the guest first
         let _: Value = client
-            .raw_request("POST", &endpoint, Some(auth_payload))
+            .raw_request(Method::POST, &endpoint, Some(auth_payload))
             .await?;
 
         // Now unauthorize the guest
@@ -199,7 +204,7 @@ impl GuestsValidator {
 
         // Make raw API call
         let response = client
-            .raw_request("POST", &endpoint, Some(unauth_payload))
+            .raw_request(Method::POST, &endpoint, Some(unauth_payload))
             .await?;
 
         // Validate response is an empty array
@@ -244,7 +249,9 @@ impl GuestsValidator {
             });
 
             // Make raw API call and check if it succeeds
-            let result = client.raw_request("POST", &endpoint, Some(payload)).await;
+            let result = client
+                .raw_request(Method::POST, &endpoint, Some(payload))
+                .await;
 
             match result {
                 Ok(response) => {
@@ -350,7 +357,9 @@ impl GuestsValidator {
             });
 
             // Make raw API call and check if it succeeds
-            let result = client.raw_request("POST", &endpoint, Some(payload)).await;
+            let result = client
+                .raw_request(Method::POST, &endpoint, Some(payload))
+                .await;
 
             match result {
                 Ok(response) => {
@@ -411,7 +420,9 @@ impl GuestsValidator {
             });
 
             // Make raw API call and check if it succeeds
-            let result = client.raw_request("POST", &endpoint, Some(payload)).await;
+            let result = client
+                .raw_request(Method::POST, &endpoint, Some(payload))
+                .await;
 
             match result {
                 Ok(response) => {
@@ -481,7 +492,9 @@ impl GuestsValidator {
             });
 
             // Make raw API call and check if it succeeds
-            let result = client.raw_request("POST", &endpoint, Some(payload)).await;
+            let result = client
+                .raw_request(Method::POST, &endpoint, Some(payload))
+                .await;
 
             match result {
                 Ok(response) => {
@@ -559,7 +572,9 @@ impl GuestsValidator {
             "bytes": 100, // 100 MB
         });
 
-        let result = client.raw_request("POST", &endpoint, Some(payload)).await;
+        let result = client
+            .raw_request(Method::POST, &endpoint, Some(payload))
+            .await;
 
         match result {
             Ok(response) => {
@@ -618,7 +633,9 @@ impl GuestsValidator {
                 payload["down"] = serde_json::json!(d);
             }
 
-            let response: Value = client.raw_request("POST", endpoint, Some(payload)).await?;
+            let response: Value = client
+                .raw_request(Method::POST, endpoint, Some(payload))
+                .await?;
 
             if let Some(first) = response.as_array().and_then(|a| a.first()).cloned() {
                 Ok(first)

--- a/examples/api_validator/guests.rs
+++ b/examples/api_validator/guests.rs
@@ -32,7 +32,7 @@ impl GuestsValidator {
 
         // Make raw API call
         let response: Value = client
-            .raw_request(Method::POST, &endpoint, Some(payload))
+            .request_json(Method::POST, &endpoint, Some(payload))
             .await?;
 
         // Validate response structure and values
@@ -113,13 +113,13 @@ impl GuestsValidator {
 
         // Authorize the guest first
         let _: Value = client
-            .raw_request(Method::POST, &endpoint, Some(auth_payload))
+            .request_json(Method::POST, &endpoint, Some(auth_payload))
             .await?;
 
         // Get the list of guests
         let endpoint = format!("/api/s/{}/stat/guest", site);
         let response: Value = client
-            .raw_request(Method::GET, &endpoint, None::<()>)
+            .request_json(Method::GET, &endpoint, None::<()>)
             .await?;
 
         // Validate response is an array
@@ -193,7 +193,7 @@ impl GuestsValidator {
 
         // Authorize the guest first
         let _: Value = client
-            .raw_request(Method::POST, &endpoint, Some(auth_payload))
+            .request_json(Method::POST, &endpoint, Some(auth_payload))
             .await?;
 
         // Now unauthorize the guest
@@ -204,7 +204,7 @@ impl GuestsValidator {
 
         // Make raw API call
         let response = client
-            .raw_request(Method::POST, &endpoint, Some(unauth_payload))
+            .request_json(Method::POST, &endpoint, Some(unauth_payload))
             .await?;
 
         // Validate response is an empty array
@@ -250,7 +250,7 @@ impl GuestsValidator {
 
             // Make raw API call and check if it succeeds
             let result = client
-                .raw_request(Method::POST, &endpoint, Some(payload))
+                .request_json(Method::POST, &endpoint, Some(payload))
                 .await;
 
             match result {
@@ -358,7 +358,7 @@ impl GuestsValidator {
 
             // Make raw API call and check if it succeeds
             let result = client
-                .raw_request(Method::POST, &endpoint, Some(payload))
+                .request_json(Method::POST, &endpoint, Some(payload))
                 .await;
 
             match result {
@@ -421,7 +421,7 @@ impl GuestsValidator {
 
             // Make raw API call and check if it succeeds
             let result = client
-                .raw_request(Method::POST, &endpoint, Some(payload))
+                .request_json(Method::POST, &endpoint, Some(payload))
                 .await;
 
             match result {
@@ -493,7 +493,7 @@ impl GuestsValidator {
 
             // Make raw API call and check if it succeeds
             let result = client
-                .raw_request(Method::POST, &endpoint, Some(payload))
+                .request_json(Method::POST, &endpoint, Some(payload))
                 .await;
 
             match result {
@@ -573,7 +573,7 @@ impl GuestsValidator {
         });
 
         let result = client
-            .raw_request(Method::POST, &endpoint, Some(payload))
+            .request_json(Method::POST, &endpoint, Some(payload))
             .await;
 
         match result {
@@ -634,7 +634,7 @@ impl GuestsValidator {
             }
 
             let response: Value = client
-                .raw_request(Method::POST, endpoint, Some(payload))
+                .request_json(Method::POST, endpoint, Some(payload))
                 .await?;
 
             if let Some(first) = response.as_array().and_then(|a| a.first()).cloned() {

--- a/examples/api_validator/sites.rs
+++ b/examples/api_validator/sites.rs
@@ -1,3 +1,4 @@
+use http::Method;
 use serde_json::Value;
 use unifi_client::{UniFiClient, UniFiResult};
 
@@ -15,7 +16,9 @@ impl SitesValidator {
         let site = self.client.site();
         let endpoint = format!("/api/s/{}/stat/sysinfo", site);
 
-        let site_info: Value = client.raw_request("GET", &endpoint, None::<()>).await?;
+        let site_info: Value = client
+            .raw_request(Method::GET, &endpoint, None::<()>)
+            .await?;
 
         // Validate site info structure
         if let Some(info) = site_info.as_array().and_then(|v| v.first()) {
@@ -33,7 +36,9 @@ impl SitesValidator {
         let client = self.client.clone();
         let endpoint = format!("/api/stat/sites");
 
-        let sites: Value = client.raw_request("GET", &endpoint, None::<()>).await?;
+        let sites: Value = client
+            .raw_request(Method::GET, &endpoint, None::<()>)
+            .await?;
 
         if let Some(sites_array) = sites.as_array() {
             if !sites_array.is_empty() {

--- a/examples/api_validator/sites.rs
+++ b/examples/api_validator/sites.rs
@@ -17,7 +17,7 @@ impl SitesValidator {
         let endpoint = format!("/api/s/{}/stat/sysinfo", site);
 
         let site_info: Value = client
-            .raw_request(Method::GET, &endpoint, None::<()>)
+            .request_json(Method::GET, &endpoint, None::<()>)
             .await?;
 
         // Validate site info structure
@@ -37,7 +37,7 @@ impl SitesValidator {
         let endpoint = format!("/api/stat/sites");
 
         let sites: Value = client
-            .raw_request(Method::GET, &endpoint, None::<()>)
+            .request_json(Method::GET, &endpoint, None::<()>)
             .await?;
 
         if let Some(sites_array) = sites.as_array() {

--- a/examples/guest_management/Cargo.lock
+++ b/examples/guest_management/Cargo.lock
@@ -1644,6 +1644,7 @@ version = "0.3.2"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "http",
  "log",
  "once_cell",
  "reqwest",

--- a/src/api/guests.rs
+++ b/src/api/guests.rs
@@ -1,5 +1,3 @@
-use reqwest::Method;
-
 use crate::models::EmptyResponse;
 use crate::{models, UniFiClient, UniFiError, UniFiResult};
 
@@ -230,10 +228,8 @@ impl AuthorizeGuestBuilder {
             ap_mac: self.access_point_mac_address,
         };
 
-        let response: Vec<models::guests::GuestEntry> = self
-            .unifi_client
-            .request(Method::POST, &endpoint, Some(request))
-            .await?;
+        let response: Vec<models::guests::GuestEntry> =
+            self.unifi_client.post(&endpoint, Some(request)).await?;
 
         response
             .into_iter()
@@ -271,7 +267,7 @@ impl ListGuestsBuilder {
             .within_hours
             .map(|hours| serde_json::json!({ "within": hours }));
 
-        self.client.request(Method::GET, &endpoint, params).await
+        self.client.get(&endpoint, params).await
     }
 }
 
@@ -292,7 +288,7 @@ impl UnauthorizeGuestBuilder {
         let request = models::guests::UnauthorizeGuestRequest::new(self.mac);
 
         self.client
-            .request(Method::POST, &endpoint, Some(request))
+            .post(&endpoint, Some(request))
             .await
             .map(|_: EmptyResponse| ())
     }

--- a/src/api/site.rs
+++ b/src/api/site.rs
@@ -52,7 +52,7 @@ impl<'a> SiteApi<'a> {
 
         let endpoint = "/api/self/sites";
 
-        let sites: Vec<Site> = client.request(Method::GET, endpoint, None::<()>).await?;
+        let sites: Vec<Site> = client.get(endpoint, None::<()>).await?;
 
         Ok(sites)
     }
@@ -154,9 +154,7 @@ impl<'a> SiteApi<'a> {
 
         let endpoint = "/api/s/default/cmd/sitemgr";
 
-        let _: serde_json::Value = client
-            .request(Method::POST, endpoint, Some(create_data))
-            .await?;
+        let _: serde_json::Value = client.post(endpoint, Some(create_data)).await?;
 
         // The API doesn't return the created site, so we need to fetch it
         self.get_by_name(name).await
@@ -200,9 +198,7 @@ impl<'a> SiteApi<'a> {
 
         let endpoint = "/api/s/default/cmd/sitemgr";
 
-        let _: serde_json::Value = client
-            .request(Method::POST, endpoint, Some(update_data))
-            .await?;
+        let _: serde_json::Value = client.post(endpoint, Some(update_data)).await?;
 
         // The API doesn't return the updated site, so we need to fetch it
         self.get(site_id).await
@@ -243,9 +239,7 @@ impl<'a> SiteApi<'a> {
 
         let endpoint = "/api/s/default/cmd/sitemgr";
 
-        let _: serde_json::Value = client
-            .request(Method::POST, endpoint, Some(delete_data))
-            .await?;
+        let _: serde_json::Value = client.post(endpoint, Some(delete_data)).await?;
 
         Ok(())
     }
@@ -299,7 +293,7 @@ impl<'a> SiteApi<'a> {
         let site = self.client.site();
         let endpoint = format!("/api/s/{}/stat/health", site);
 
-        let stats: Vec<SiteStats> = client.request(Method::GET, &endpoint, None::<()>).await?;
+        let stats: Vec<SiteStats> = client.get(&endpoint, None::<()>).await?;
 
         stats
             .into_iter()

--- a/src/models/guests.rs
+++ b/src/models/guests.rs
@@ -75,7 +75,7 @@ pub enum GuestEntry {
         #[serde(skip_serializing_if = "Option::is_none")]
         qos_rate_max_up: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        qos_usage_quota: Option<u64>,
+        qos_usage_quota: Option<i64>,
     },
     /// A guest authorization that has been authorized but not yet connected to
     /// the network or has expired
@@ -98,7 +98,7 @@ pub enum GuestEntry {
         #[serde(skip_serializing_if = "Option::is_none")]
         qos_rate_max_up: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        qos_usage_quota: Option<u64>,
+        qos_usage_quota: Option<i64>,
     },
     /// A newly authorized guest (response from authorize-guest command)
     New {
@@ -117,7 +117,7 @@ pub enum GuestEntry {
         #[serde(skip_serializing_if = "Option::is_none")]
         qos_rate_max_up: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        qos_usage_quota: Option<u64>,
+        qos_usage_quota: Option<i64>,
     },
 }
 

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -31,7 +31,7 @@ async fn test_successful_login() -> Result<(), UniFiError> {
 
         let client = setup_test_client(&mock_server.uri()).await;
         let result = client
-            .raw_request(Method::GET, "/api/self", None::<()>)
+            .request_json(Method::GET, "/api/self", None::<()>)
             .await;
         assert!(result.is_ok());
     }

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -1,3 +1,4 @@
+use http::Method;
 use serde_json::json;
 use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -29,7 +30,9 @@ async fn test_successful_login() -> Result<(), UniFiError> {
         .await;
 
         let client = setup_test_client(&mock_server.uri()).await;
-        let result = client.raw_request("GET", "/api/self", None::<()>).await;
+        let result = client
+            .raw_request(Method::GET, "/api/self", None::<()>)
+            .await;
         assert!(result.is_ok());
     }
     Ok(())


### PR DESCRIPTION
## Summary


- Introduce `request_json()` that validates UniFi’s standard response shape (`{ meta.rc, data }`) and returns the data as `serde_json::Value`.
- Add typed convenience wrappers `get<T,R>()` and `post<T,R>()` that deserialize standard responses into `R`.
- Replace internal call sites to use new wrappers:
  - `src/api/site.rs`: switch from `client.request` to `client.get`/`client.post`
  - `src/api/guests.rs`: switch from `client.request` to `client.get`/`client.post`
- Update examples and tests to use `request_json` instead of `raw_request` where JSON was expected:
  - `examples/api_validator/{guests.rs,sites.rs}`
  - `tests/auth_tests.rs`
- Standardize doc comments in `src/client.rs` to match `raw_request()` style:
  - Add Warning/Arguments/Errors/Returns/Examples sections
  - Document builder methods, `site()`, `guests()`, `request_json()`, `get()`, `post()`

## ⚠️ BREAKING CHANGE:
- `raw_request()` now returns `reqwest::Response` instead of `serde_json::Value`. For endpoints returning the standard `{ meta, data }` payload, use `request_json()` or the typed `get()`/`post()` helpers.
