### PR TITLE
Improve UniFi client auth resilience and request validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["unifi", "ubiquiti", "api", "client"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-arc-swap = "1.7"
+arc-swap = { version = "1.7", optional = true }
 async-trait = "0.1"
 http = "1"
 log = "0.4"
@@ -32,3 +32,7 @@ rand = "0.9"
 tokio-test = "0.4"
 wiremock = "=0.6.3"
 chrono = { version = "0.4", features = ["clock"] }
+
+[features]
+default = ["default-client"]
+default-client = ["dep:arc-swap"]

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ use reqwest::Client as ReqwestClient;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let custom_http_client = ReqwestClient::builder()
         .timeout(std::time::Duration::from_secs(60))
+        .redirect(Policy::none())
+        .cookie_store(true)
         .build()?;
 
     let client = UniFiClient::builder()

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ async fn main() -> Result<(), UniFiError> {
         .build()
         .await?;
     unifi_client::initialize(client);
-    
+
     let unifi_client = unifi_client::instance();
 
     // Authorize a guest:
@@ -169,8 +169,25 @@ UniFiClient supports two patterns for client creation and access:
 
 **Best Practices:**
 - **Single Controller:** Call `initialize()` early (typically in `main`) and use `instance()` anywhere else.
+  - Note: If `initialize()` isn’t called, `instance()` refers to an inert default client; any requests will return a configuration error.
 - **Multiple or Custom Instances:** Use the builder to create each client independently.
-- If `initialize()` isn’t called, any singleton usage should gracefully return a configuration error.
+
+### Feature Flags
+
+- `default-client` (enabled by default):
+  - Provides the global singleton (`initialize()` / `instance()`), implemented with a
+    thread-safe `Arc` and `ArcSwap`.
+  - Starts with an inert default client (invalid URL, no credentials, cookie store enabled).
+  - Recommended for apps that interact with a single controller and prefer global access.
+
+Disable the global client if you want explicit dependency injection only:
+
+```toml
+[dependencies]
+unifi-client = { version = "*", default-features = false }
+```
+
+When disabled, call `UniFiClient::builder()` and pass the client handle through your application.
 
 ### Creating Multiple Clients
 

--- a/examples/api_validator/main.rs
+++ b/examples/api_validator/main.rs
@@ -40,7 +40,8 @@ async fn main() -> UniFiResult<()> {
         .username(&cli.username)
         .password(&cli.password)
         .site("default")
-        .verify_ssl(false)
+        // Dangerous, only use for lab environments or testing
+        .accept_invalid_certs(true)
         .build()
         .await
         .expect("Failed to build UniFiClient");

--- a/examples/guest_management/README.md
+++ b/examples/guest_management/README.md
@@ -22,7 +22,7 @@ export UNIFI_CONTROLLER="https://unifi.example.com:8443"
 export UNIFI_USERNAME="admin"
 export UNIFI_PASSWORD="password"
 export UNIFI_SITE="default"
-export UNIFI_VERIFY_SSL="false"
+export UNIFI_ACCEPT_INVALID_CERTS="true"
 
 # Run the example
 cargo run
@@ -43,7 +43,7 @@ cargo run
 - `UNIFI_USERNAME`: Username for authentication (default: "admin")
 - `UNIFI_PASSWORD`: Password for authentication (optional, will prompt if not set)
 - `UNIFI_SITE`: Site to manage guests for (default: "default")
-- `UNIFI_VERIFY_SSL`: Whether to verify SSL certificates (default: false)
+- `UNIFI_ACCEPT_INVALID_CERTS`: Whether to accept invalid SSL certificates (default: false)
 
 ## Menu Options
 

--- a/examples/guest_management/main.rs
+++ b/examples/guest_management/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|_| "https://unifi.example.com:8443".to_string());
     let username = env::var("UNIFI_USERNAME").unwrap_or_else(|_| "admin".to_string());
     let site = env::var("UNIFI_SITE").unwrap_or_else(|_| "default".to_string());
-    let verify_ssl = env::var("UNIFI_VERIFY_SSL")
+    let accept_invalid_certs = env::var("UNIFI_ACCEPT_INVALID_CERTS")
         .map(|v| v.to_lowercase() == "true")
         .unwrap_or(false);
 
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .username(&username)
         .password_from_env("UNIFI_PASSWORD")
         .site(&site)
-        .verify_ssl(verify_ssl)
+        .accept_invalid_certs(accept_invalid_certs)
         .build()
         .await?;
     println!("✅ Authentication successful!");

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ pub enum UniFiError {
     #[error("URL parse error: {0}")]
     UrlParseError(#[from] UrlParseError),
 
+    /// The API endpoint/path string is invalid.
+    #[error("Invalid endpoint: {0}")]
+    InvalidEndpoint(String),
+
     /// Error serializing or deserializing JSON.
     #[error("Serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,18 @@
 //!     #    .password_from_env("UNIFI_PASSWORD")
 //!     #    .build()
 //!     #    .await?;
-//!     # unifi_client::initialize(client);
-//! let unifi_client = unifi_client::instance();
+//!     # let unifi_client = {
+//!     #     #[cfg(feature = "default-client")]
+//!     #     {
+//!     #         unifi_client::initialize(client);
+//!     #         unifi_client::instance()
+//!     #     }
+//!     #     #[cfg(not(feature = "default-client"))]
+//!     #     {
+//!     #         client
+//!     #     }
+//!     # };
+//! let unifi_client = unifi_client;
 //! // Authorize a guest with optional parameters.
 //! let new_guest = unifi_client
 //!     .guests()
@@ -63,5 +73,7 @@ mod error;
 pub mod models;
 
 pub use self::api::guests;
-pub use self::client::{initialize, instance, UniFiClient, UniFiClientBuilder};
+#[cfg(feature = "default-client")]
+pub use self::client::{initialize, instance};
+pub use self::client::{UniFiClient, UniFiClientBuilder};
 pub use self::error::{UniFiError, UniFiResult};

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -65,7 +65,7 @@ async fn test_failed_login_invalid_credentials() -> Result<(), UniFiError> {
             .username("test-user")
             .password("wrong-password")
             .site("default")
-            .verify_ssl(false)
+            .accept_invalid_certs(false)
             .build()
             .await;
 
@@ -103,7 +103,7 @@ async fn test_login_server_error() {
             .username("test-user")
             .password("test-password")
             .site("default")
-            .verify_ssl(false)
+            .accept_invalid_certs(false)
             .build()
             .await;
 
@@ -143,7 +143,7 @@ async fn test_login_no_cookies() {
             .username("test-user")
             .password("test-password")
             .site("default")
-            .verify_ssl(false)
+            .accept_invalid_certs(false)
             .build()
             .await;
 
@@ -184,7 +184,7 @@ async fn test_config_error() {
         .username("test-user")
         .password("test-password")
         .site("default")
-        .verify_ssl(false)
+        .accept_invalid_certs(false)
         .build()
         .await;
 

--- a/tests/auth_tests.rs
+++ b/tests/auth_tests.rs
@@ -1,6 +1,6 @@
-use http::Method;
+use http::{Method, StatusCode};
 use serde_json::json;
-use wiremock::matchers::{body_json, method, path};
+use wiremock::matchers::{body_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
@@ -13,6 +13,12 @@ use unifi_client::{UniFiClient, UniFiError};
 
 #[tokio::test]
 async fn test_successful_login() -> Result<(), UniFiError> {
+    // What it tests: Verifies the full happy path for both controller kinds (Network and OS):
+    // probe -> login -> authenticated GET that includes the right auth material
+    // (cookie for Network, cookie + CSRF for OS).
+    //
+    // Why it's valuable: Serves as a smoke test for the core flow and header injection logic. It
+    // quickly catches regressions in detection, login, and basic authenticated I/O.
     for &kind in &[TestControllerKind::Network, TestControllerKind::Os] {
         let mock_server = MockServer::start().await;
 
@@ -40,6 +46,11 @@ async fn test_successful_login() -> Result<(), UniFiError> {
 
 #[tokio::test]
 async fn test_failed_login_invalid_credentials() -> Result<(), UniFiError> {
+    // What it tests: Login failure with invalid credentials for both controller kinds, including
+    // the expected status codes (Network: 400; OS: 403) and error propagation.
+    //
+    // Why it's valuable: Ensures clear, deterministic error mapping for credential
+    // failures so callers can handle auth errors reliably across controller variants.
     for &kind in &[TestControllerKind::Network, TestControllerKind::Os] {
         let mock_server = MockServer::start().await;
         setup_probe(&mock_server, kind).await;
@@ -88,6 +99,11 @@ async fn test_failed_login_invalid_credentials() -> Result<(), UniFiError> {
 
 #[tokio::test]
 async fn test_login_server_error() {
+    // What it tests: Server-side error during login (HTTP 500) results in an AuthenticationError
+    // that includes the failing status.
+    //
+    // Why it's valuable: Validates that infrastructure outages or upstream faults are surfaced
+    // transparently (no silent retries or misleading errors).
     for &kind in &[TestControllerKind::Network, TestControllerKind::Os] {
         let mock_server = MockServer::start().await;
         setup_probe(&mock_server, kind).await;
@@ -119,6 +135,11 @@ async fn test_login_server_error() {
 
 #[tokio::test]
 async fn test_login_no_cookies() {
+    // What it tests: Login succeeds with 200 but the server omits 'Set-Cookie' → the builder
+    // fails with "No cookies received from server" for both controller kinds.
+    //
+    // Why it's valuable: The cookie is the session anchor. This guards against partially-formed
+    // "successful" logins that would later fail with puzzling 401s.
     for &kind in &[TestControllerKind::Network, TestControllerKind::Os] {
         let mock_server = MockServer::start().await;
         setup_probe(&mock_server, kind).await;
@@ -158,113 +179,149 @@ async fn test_login_no_cookies() {
 }
 
 #[tokio::test]
-async fn test_ensure_authenticated_with_empty_username() {
-    // Using the inert default client yields an empty username and no password.
-    // Calling any request path should fail fast in ensure_authenticated()
-    // with a configuration error for the username, before any network I/O.
-    let client = UniFiClient::default();
+async fn test_csrf_rotation_on_success_response() -> Result<(), UniFiError> {
+    // What it tests: On UniFi OS, the server rotates the CSRF token via 'x-updated-csrf-token' on
+    // a success response (200 or 204). The next request must present the new token.
+    //
+    // Why it's valuable: CSRF rotation can happen on success; this verifies mid-session token
+    // update is handled correctly to prevent false 403/401s and stale-header reuse.
+    let mock_server = MockServer::start().await;
+    setup_probe_and_login(&mock_server, TestControllerKind::Os).await;
 
+    // Use distinct endpoints to prevent matcher collisions between cases.
+    let cases: &[(u16, &str)] = &[(200, "/api/self-200"), (204, "/api/self-204")];
+
+    for (status, ep) in cases {
+        let endpoint = api_path(TestControllerKind::Os, ep);
+        let rotated = format!("rotated-{}", status);
+
+        // 1) First request uses the original CSRF and receives a rotated token in response.
+        Mock::given(method("GET"))
+            .and(path(endpoint.as_str()))
+            .and(header("cookie", "TOKEN=test-token"))
+            .and(header("x-csrf-token", "test-csrf"))
+            .respond_with(
+                ResponseTemplate::new(*status)
+                    .insert_header("x-updated-csrf-token", rotated.clone()),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // 2) Second request must use the rotated CSRF.
+        Mock::given(method("GET"))
+            .and(path(endpoint.as_str()))
+            .and(header("cookie", "TOKEN=test-token"))
+            .and(header("x-csrf-token", rotated.clone()))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        // Build a fresh client (per-case) so state starts in a known condition.
+        let client = setup_test_client(&mock_server.uri()).await;
+
+        // First call triggers the rotation.
+        let resp1 = client.request(Method::GET, ep, None::<()>).await?;
+        assert_eq!(resp1.status(), StatusCode::from_u16(*status).unwrap());
+
+        // Second call must present the rotated CSRF to match the second mock (=> 200).
+        let resp2 = client.request(Method::GET, ep, None::<()>).await?;
+        assert_eq!(resp2.status(), StatusCode::OK);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_csrf_cleared_after_relogin_without_csrf_header() -> Result<(), UniFiError> {
+    // What it tests: After a 401 triggers re-login on UniFi OS, if the new login response does not
+    // include 'x-csrf-token', the stored CSRF is cleared and subsequent requests do
+    // NOT send the header (and succeed).
+    //
+    // Why it's valuable: Proves that session state is fully reset across re-auth, avoiding sending
+    // an invalid CSRF header that can cause 403s. Prevents "sticky" CSRF bugs.
+    let mock_server = MockServer::start().await;
+    setup_probe(&mock_server, TestControllerKind::Os).await;
+
+    // Arrange login sequence: first login returns a CSRF token, re-login omits it.
+    let login_path = TestControllerKind::Os.login_path();
+    let login_body = serde_json::json!({
+        "username": "test-user",
+        "password": "test-password"
+    });
+
+    // Initial login (no cookie yet) seeds CSRF state; remove the mock afterward so re-login uses
+    // the dedicated stub below.
+    let client = {
+        let _initial_login_guard = Mock::given(method("POST"))
+            .and(path(login_path))
+            .and(body_json(login_body.clone()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("set-cookie", "TOKEN=test-token; path=/")
+                    .insert_header("x-csrf-token", "test-csrf"),
+            )
+            .expect(1)
+            .mount_as_scoped(&mock_server)
+            .await;
+
+        setup_test_client(&mock_server.uri()).await
+    };
+
+    let endpoint = api_path(TestControllerKind::Os, "/api/self");
+
+    // 1) The first GET must include the original CSRF and gets forced to 401 to trigger re-auth. We
+    //    also keep the cookie matcher to make the intent explicit.
+    let first_get_unauthorized = Mock::given(method("GET"))
+        .and(path(endpoint.as_str()))
+        .and(header("cookie", "TOKEN=test-token"))
+        .and(header("x-csrf-token", "test-csrf"))
+        .respond_with(ResponseTemplate::new(401));
+    first_get_unauthorized.mount(&mock_server).await;
+
+    // 2) Re-login succeeds but does NOT return x-csrf-token. It sets a new cookie
+    //    TOKEN=second-token.
+    let relogin_without_csrf = Mock::given(method("POST"))
+        .and(path(login_path))
+        .and(header("cookie", "TOKEN=test-token"))
+        .and(body_json(login_body))
+        .respond_with(
+            ResponseTemplate::new(200).insert_header("set-cookie", "TOKEN=second-token; path=/"),
+        )
+        .expect(1);
+    relogin_without_csrf.mount(&mock_server).await;
+
+    // 3a) Success mock for the retried GET: expects the *new* cookie but does NOT constrain CSRF.
+    //     This is the happy-path response (200, rc=ok).
+    let retried_get_success = Mock::given(method("GET"))
+        .and(path(endpoint.as_str()))
+        .and(header("cookie", "TOKEN=second-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "meta": { "rc": "ok" },
+            "data": []
+        })));
+    retried_get_success.mount(&mock_server).await;
+
+    // 3b) Poison pill mock for the retried GET: if a CSRF header is still present alongside
+    //     the new cookie, this mock will match and return 418.
+    //     We mount this AFTER the success mock so it has higher precedence (wiremock picks
+    //     the last matching mock). If the header exists, this one wins → test fails.
+    let retried_get_poison_if_csrf_present = Mock::given(method("GET"))
+        .and(path(endpoint.as_str()))
+        .and(header("cookie", "TOKEN=second-token"))
+        .and(header_exists("x-csrf-token"))
+        .respond_with(ResponseTemplate::new(418)); // any non-2xx sentinel is fine
+    retried_get_poison_if_csrf_present.mount(&mock_server).await;
+
+    // Perform the call (first GET -> 401 -> re-login (no CSRF) -> retry -> 200)
     let result = client
-        .request_json::<()>(Method::GET, "/api/self", None)
+        .request_json(http::Method::GET, "/api/self", None::<()>)
         .await;
 
-    match result {
-        Err(UniFiError::ConfigurationError(msg)) => {
-            assert_eq!(msg, "Username is required");
-        }
-        other => panic!("Expected ConfigurationError, got: {:?}", other),
-    }
-}
+    // If CSRF wasn't cleared, the poison mock would have matched and we'd get an error here.
+    assert!(
+        result.is_ok(),
+        "expected success after CSRF cleared, got {result:?}"
+    );
 
-#[tokio::test]
-async fn test_config_error() {
-    // Test invalid URL
-    let unifi_client = UniFiClient::builder()
-        .controller_url("invalid-url")
-        .username("test-user")
-        .password("test-password")
-        .site("default")
-        .accept_invalid_certs(false)
-        .build()
-        .await;
-
-    assert!(unifi_client.is_err());
-    match unifi_client {
-        Err(UniFiError::ConfigurationError(msg)) => {
-            assert!(msg.contains("Invalid controller URL"));
-        }
-        _ => panic!("Expected ConfigurationError"),
-    }
-
-    // Test missing username
-    let unifi_client = UniFiClient::builder()
-        .controller_url("https://example.com")
-        // No username
-        .password("test-password")
-        .site("default")
-        .build()
-        .await;
-
-    assert!(unifi_client.is_err());
-    match unifi_client {
-        Err(UniFiError::ConfigurationError(msg)) => {
-            assert_eq!(msg, "Username is required");
-        }
-        _ => panic!("Expected ConfigurationError"),
-    }
-}
-
-#[tokio::test]
-async fn test_builder_rejects_empty_username_and_password() {
-    // Empty username should be rejected before URL parsing/network.
-    let err = UniFiClient::builder()
-        .controller_url("https://example.com")
-        .username("")
-        .password("non-empty")
-        .build()
-        .await
-        .unwrap_err();
-    match err {
-        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Username is required"),
-        other => panic!("Expected ConfigurationError for username, got {other:?}"),
-    }
-
-    // Empty password should be rejected as well.
-    let err = UniFiClient::builder()
-        .controller_url("https://example.com")
-        .username("user")
-        .password("")
-        .build()
-        .await
-        .unwrap_err();
-    match err {
-        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Password is required"),
-        other => panic!("Expected ConfigurationError for password, got {other:?}"),
-    }
-
-    // Whitespace-only username should also be rejected.
-    let err = UniFiClient::builder()
-        .controller_url("https://example.com")
-        .username("   ")
-        .password("non-empty")
-        .build()
-        .await
-        .unwrap_err();
-    match err {
-        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Username is required"),
-        other => panic!("Expected ConfigurationError for username whitespace, got {other:?}"),
-    }
-
-    // Whitespace-only password should also be rejected.
-    let err = UniFiClient::builder()
-        .controller_url("https://example.com")
-        .username("user")
-        .password("   ")
-        .build()
-        .await
-        .unwrap_err();
-    match err {
-        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Password is required"),
-        other => panic!("Expected ConfigurationError for password whitespace, got {other:?}"),
-    }
+    Ok(())
 }

--- a/tests/builder_tests.rs
+++ b/tests/builder_tests.rs
@@ -1,0 +1,122 @@
+use unifi_client::{UniFiClient, UniFiError};
+
+#[tokio::test]
+async fn test_config_error() {
+    // What it tests: Builder‑time validation of required/structured fields. It covers:
+    // (1) a controller URL that fails to parse, and (2) a missing username.
+    //
+    // Why it's valuable: Fails fast before any network I/O, producing specific
+    // ConfigurationError messages that make misconfiguration obvious to callers and reduce
+    // debugging time.
+
+    // Test invalid URL
+    let err = UniFiClient::builder()
+        .controller_url("invalid-url")
+        .username("test-user")
+        .password("test-password")
+        .site("default")
+        .accept_invalid_certs(false)
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => {
+            assert!(msg.contains("Invalid controller URL"));
+        }
+        other => panic!("Expected ConfigurationError for invalid URL, got {other:?}"),
+    }
+
+    // Test missing username
+    let err = UniFiClient::builder()
+        .controller_url("https://example.com")
+        // No username
+        .password("test-password")
+        .site("default")
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Username is required"),
+        other => panic!("Expected ConfigurationError for missing username, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_builder_rejects_empty_username_and_password() {
+    // What it tests: The builder rejects empty and whitespace‑only credentials. Both username
+    // and password must be present after trimming.
+    //
+    // Why it's valuable: Enforces a clear, secure contract on input early on, preventing subtle
+    // runtime failures or accidental empty credentials from reaching the network layer.
+
+    // Empty username should be rejected before URL parsing/network.
+    let err = UniFiClient::builder()
+        .controller_url("https://example.com")
+        .username("")
+        .password("non-empty")
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Username is required"),
+        other => panic!("Expected ConfigurationError for username, got {other:?}"),
+    }
+
+    // Empty password should be rejected as well.
+    let err = UniFiClient::builder()
+        .controller_url("https://example.com")
+        .username("user")
+        .password("")
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Password is required"),
+        other => panic!("Expected ConfigurationError for password, got {other:?}"),
+    }
+
+    // Whitespace-only username should also be rejected.
+    let err = UniFiClient::builder()
+        .controller_url("https://example.com")
+        .username("   ")
+        .password("non-empty")
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Username is required"),
+        other => panic!("Expected ConfigurationError for username whitespace, got {other:?}"),
+    }
+
+    // Whitespace-only password should also be rejected.
+    let err = UniFiClient::builder()
+        .controller_url("https://example.com")
+        .username("user")
+        .password("   ")
+        .build()
+        .await
+        .unwrap_err();
+    match err {
+        UniFiError::ConfigurationError(msg) => assert_eq!(msg, "Password is required"),
+        other => panic!("Expected ConfigurationError for password whitespace, got {other:?}"),
+    }
+}
+
+#[cfg(debug_assertions)]
+#[tokio::test]
+#[should_panic(
+    expected = "Client must be constructed via `build()` which performs an initial login"
+)]
+async fn test_default_client_panics_in_debug_without_build() {
+    // What it tests: The debug‑only guard that prevents using the inert `UniFiClient::default()`
+    // without going through the builder (and initial login). Calling a request method must panic
+    // with a clear message in debug builds.
+    //
+    // Why it's valuable: Guides users toward the correct construction path during development and
+    // catches a common misuse early, before it turns into intermittent auth failures at runtime.
+    use http::Method;
+    let client = UniFiClient::default();
+    let _ = client
+        .request_json::<()>(Method::GET, "/api/self", None)
+        .await;
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -68,11 +68,10 @@ pub async fn setup_probe_and_login(server: &MockServer, kind: TestControllerKind
             resp = resp
                 .set_body_json(json!({ "meta": { "rc": "ok" }, "data": [] }))
                 .insert_header("set-cookie", "unifises=test-cookie")
-                .insert_header("x-csrf-token", "test-csrf");
         }
         TestControllerKind::Os => {
             resp = resp
-                .insert_header("set-cookie", "TOKEN=test-token; Path=/")
+                .insert_header("set-cookie", "TOKEN=test-token; path=/")
                 .insert_header("x-csrf-token", "test-csrf");
         }
     }
@@ -98,7 +97,7 @@ pub fn api_path(kind: TestControllerKind, endpoint: &str) -> String {
 
 pub fn csrf_header_for(kind: TestControllerKind) -> Option<(&'static str, &'static str)> {
     match kind {
-        TestControllerKind::Network => Some(("x-csrf-token", "test-csrf")),
+        TestControllerKind::Network => None,
         TestControllerKind::Os => Some(("x-csrf-token", "test-csrf")),
     }
 }

--- a/tests/request_tests.rs
+++ b/tests/request_tests.rs
@@ -1,0 +1,143 @@
+use http::Method;
+use serde_json::json;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+
+use common::{api_path, setup_probe, setup_probe_and_login, setup_test_client, TestControllerKind};
+use unifi_client::UniFiError;
+
+#[tokio::test]
+async fn test_invalid_endpoint_rejected() -> Result<(), UniFiError> {
+    // What it tests: The client rejects endpoints containing a query string (or fragment) and
+    // surfaces a UniFiError::InvalidEndpoint instead of silently mangling the URL.
+    // Although this runs against an OS mock, the invariant is endpoint-shape only and applies
+    // uniformly across controller kinds.
+    //
+    // Why it's valuable: Prevents subtle bugs where `?query` would be pushed as path segments.
+    // It forces callers to follow the library contract (“path only”), fails fast at the callsite,
+    // and avoids confusing controller-side 404/401s originating from malformed paths.
+    let mock_server = MockServer::start().await;
+
+    setup_probe_and_login(&mock_server, TestControllerKind::Os).await;
+
+    let client = setup_test_client(&mock_server.uri()).await;
+    match client
+        .request(Method::GET, "/api/self?foo=bar", None::<()>)
+        .await
+    {
+        Err(UniFiError::InvalidEndpoint(msg)) => {
+            assert!(msg.contains("endpoint must not include query"));
+        }
+        other => panic!("expected InvalidEndpoint error for query-bearing path, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_request_retries_once_on_403_os() -> Result<(), UniFiError> {
+    // What it tests: On UniFi OS, a 403 on the first request triggers exactly one re-login and
+    // a single retry using the refreshed cookie + rotated CSRF. The test asserts both the success
+    // of the retried request and the precise number of attempts (two GETs, two POSTs to login).
+    //
+    // Why it's valuable: Validates the critical re-auth policy for OS (treat 403 as re-auth
+    // signal), ensures we neither skip the retry (leading to spurious failures) nor over-retry
+    // (risking loops / traffic storms), and confirms header/cookie rotation is wired correctly.
+    let mock_server = MockServer::start().await;
+    setup_probe(&mock_server, TestControllerKind::Os).await;
+
+    let login_path = TestControllerKind::Os.login_path();
+    let login_body = json!({
+        "username": "test-user",
+        "password": "test-password"
+    });
+
+    let client = {
+        let _initial_login = Mock::given(method("POST"))
+            .and(path(login_path))
+            .and(body_json(login_body.clone()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("set-cookie", "TOKEN=test-token; path=/")
+                    .insert_header("x-csrf-token", "test-csrf"),
+            )
+            .expect(1)
+            .mount_as_scoped(&mock_server)
+            .await;
+
+        setup_test_client(&mock_server.uri()).await
+    };
+
+    let endpoint_path = api_path(TestControllerKind::Os, "/api/self");
+
+    // First attempt returns 403 with the original credentials, forcing a re-authentication.
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.as_str()))
+        .and(header("cookie", "TOKEN=test-token"))
+        .and(header("x-csrf-token", "test-csrf"))
+        .respond_with(ResponseTemplate::new(403))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // The client should retry exactly once by re-authenticating.
+    Mock::given(method("POST"))
+        .and(path(login_path))
+        .and(header("cookie", "TOKEN=test-token"))
+        .and(body_json(login_body.clone()))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("set-cookie", "TOKEN=second-token; path=/")
+                .insert_header("x-csrf-token", "rotated-csrf"),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // The retried request must succeed using the rotated credentials.
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.as_str()))
+        .and(header("cookie", "TOKEN=second-token"))
+        .and(header("x-csrf-token", "rotated-csrf"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "meta": { "rc": "ok" },
+            "data": []
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Execute the request: the client will perform the initial attempt, see the 403, re-login once,
+    // and retry successfully.
+    let result = client
+        .request_json(Method::GET, "/api/self", None::<()>)
+        .await?;
+    assert!(result.is_array());
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("failed to read recorded requests");
+
+    let get_attempts = requests
+        .iter()
+        .filter(|req| req.method == Method::GET && req.url.path() == endpoint_path)
+        .count();
+    assert_eq!(
+        get_attempts, 2,
+        "expected exactly two GET attempts (original + retry), saw {get_attempts}"
+    );
+
+    let login_attempts = requests
+        .iter()
+        .filter(|req| req.method == Method::POST && req.url.path() == login_path)
+        .count();
+    assert_eq!(
+        login_attempts, 2,
+        "expected initial login plus one re-authentication, saw {login_attempts}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Summary

- replace the ad-hoc auth fields with a dedicated `AuthState` that tracks CSRF, serializes re-logins, and rotates tokens when the controller sends `x-updated-csrf-token` (UniFi OS only).
- improve `request()` to retry exactly once on UniFi OS 401/403 responses, sharing retries across concurrent callers via single-flight re-authentication
- reject endpoints containing queries or fragments and surface a new `InvalidEndpoint` error, with unit and integration coverage
- split builder/request-focused tests into their own files and add scenarios for CSRF rotation/clearing and the 403 retry path

### Testing
- Added tests covering auth, `UniFiClientBuilder`, and HTTP requests